### PR TITLE
[PKG-2689] opencensus-proto 0.4.1- rebuild for py311 support ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,4 @@
-aggregate_check: false
+
 upload_channels:
   - sfe1ed40
-  - services
-channels:
-  - sfe1ed40
-  - services
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,19 @@
-{% set author = "census-instrumentation" %}
 {% set name = "opencensus-proto" %}
 {% set version = "0.4.1" %}
-{% set sha256 = "e3d89f7f9ed84c9b6eee818c2e9306950519402bf803698b15c310b77ca2f0f3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ author }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/census-instrumentation/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: e3d89f7f9ed84c9b6eee818c2e9306950519402bf803698b15c310b77ca2f0f3
 
 build:
-  number: 0
+  number: 1
   script: 
     - cd gen-python
-    - {{ PYTHON }} -m pip install . -vv --no-deps
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -31,16 +29,16 @@ test:
   imports:
     - opencensus
     - opencensus.proto
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/census-instrumentation/opencensus-proto
   summary: OpenCensus Proto - Language Independent Interface Types For OpenCensus
   license: Apache-2.0
-  license_type: Apache
+  license_family: Apache
   license_file: LICENSE
   description: |
     Census provides a framework to define and collect stats against metrics and to
@@ -50,7 +48,6 @@ about:
     and Java). The API interface types are defined using protos to ensure
     consistency and interoperability for the different implementations.
   doc_url: https://github.com/census-instrumentation/opencensus-proto/blob/master/README.md
-  doc_source_url: https://github.com/census-instrumentation/opencensus-proto
   dev_url: https://github.com/census-instrumentation/opencensus-proto
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/census-instrumentation/opencensus-proto/releases
License: https://github.com/census-instrumentation/opencensus-proto/blob/v0.4.1/LICENSE
Requirements: https://github.com/census-instrumentation/opencensus-proto/blob/v0.4.1/gen-python/setup.py

Actions:
1. Update `abs.yaml`
2. Increase the build number to `1`
3. Add `--no-build-isolation` to `script`
4. Add `license_family` and remove an incorrect `license_type` 
5. Remove `doc_source_url`