### PR TITLE
Rebuild 0.4.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-
-upload_channels:
-  - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: e3d89f7f9ed84c9b6eee818c2e9306950519402bf803698b15c310b77ca2f0f3
 
 build:
-  number: 2
-  script: 
+  number: 3
+  script:
     - cd gen-python
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 


### PR DESCRIPTION
## ☆ Opencensus-proto 0.4.1 Rebuild For Default Channel ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5984)
[Upstream](https://github.com/census-instrumentation/opencensus-proto)

### Changes
 - Rebuild for `opentelemetry-python` with removal of `abs.yaml`
 - Build number bump